### PR TITLE
Remove duplicate unnecessary dependencies in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppetlabs_spec_helper"
+  gem "rspec-puppet"
+  gem 'puppetlabs_spec_helper', '~> 1.2.2'
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
-  gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "rspec", '< 3.2.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"


### PR DESCRIPTION
They were already present in rspec-puppet.
This shoud fix `undefined method `last_comment'` during Travis run
NB: rake 11.0+ requires rspec > 3.4.4 (see https://github.com/rspec/rspec-core/pull/2197)